### PR TITLE
chore(deps): upgrade dependencies

### DIFF
--- a/diff.txt
+++ b/diff.txt
@@ -1,0 +1,294 @@
+diff --git a/package.json b/package.json
+index 08b60ea..684a751 100644
+--- a/package.json
++++ b/package.json
+@@ -40,7 +40,7 @@
+     "aws-cdk-lib": "2.164.1",
+     "constructs": "^10.4.2",
+     "js-yaml": "^4.1.0",
+-    "p6-cdk-website-plus": "^0.3.5",
++    "p6-cdk-website-plus": "^1.0.0",
+     "source-map-support": "^0.5.21"
+   },
+   "keywords": [
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 3d144f8..010348b 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -18,8 +18,8 @@ importers:
+         specifier: ^4.1.0
+         version: 4.1.0
+       p6-cdk-website-plus:
+-        specifier: ^0.3.5
+-        version: 0.3.5(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2)
++        specifier: ^1.0.0
++        version: 1.0.0(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2)
+       source-map-support:
+         specifier: ^0.5.21
+         version: 0.5.21
+@@ -137,20 +137,20 @@ packages:
+       - jsonschema
+       - semver
+ 
+-  '@babel/code-frame@7.26.0':
+-    resolution: {integrity: sha512-INCKxTtbXtcNbUZ3YXutwMpEleqttcswhAdee7dhuoVrD2cnuc3PqtERBtxkX5nziX9vnBL8WXmSGwv8CuPV6g==}
++  '@babel/code-frame@7.26.2':
++    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
+     engines: {node: '>=6.9.0'}
+ 
+-  '@babel/compat-data@7.26.0':
+-    resolution: {integrity: sha512-qETICbZSLe7uXv9VE8T/RWOdIE5qqyTucOt4zLYMafj2MRO271VGgLd4RACJMeBO37UPWhXiKMBk7YlJ0fOzQA==}
++  '@babel/compat-data@7.26.2':
++    resolution: {integrity: sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==}
+     engines: {node: '>=6.9.0'}
+ 
+   '@babel/core@7.26.0':
+     resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
+     engines: {node: '>=6.9.0'}
+ 
+-  '@babel/generator@7.26.0':
+-    resolution: {integrity: sha512-/AIkAmInnWwgEAJGQr9vY0c66Mj6kjkE2ZPB1PurTRaRAh3U+J45sAQMjQDJdh4WbR3l0x5xkimXBKyBXXAu2w==}
++  '@babel/generator@7.26.2':
++    resolution: {integrity: sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==}
+     engines: {node: '>=6.9.0'}
+ 
+   '@babel/helper-compilation-targets@7.25.9':
+@@ -187,8 +187,8 @@ packages:
+     resolution: {integrity: sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==}
+     engines: {node: '>=6.9.0'}
+ 
+-  '@babel/parser@7.26.1':
+-    resolution: {integrity: sha512-reoQYNiAJreZNsJzyrDNzFQ+IQ5JFiIzAHJg9bn94S3l+4++J7RsIhNMoB+lgP/9tpmiAQqspv+xfdxTSzREOw==}
++  '@babel/parser@7.26.2':
++    resolution: {integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==}
+     engines: {node: '>=6.0.0'}
+     hasBin: true
+ 
+@@ -2150,8 +2150,8 @@ packages:
+     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+     engines: {node: '>=6'}
+ 
+-  p6-cdk-website-plus@0.3.5:
+-    resolution: {integrity: sha512-NN3g+5+Hrr8yMRiqRvVoblT1dRXEa0vpIXwiilT+as0wP4rJMZ0f+aU8M8+YePxjO9phaPPgEsEo38QBGV8Efw==}
++  p6-cdk-website-plus@1.0.0:
++    resolution: {integrity: sha512-UUHIQPUzEMrThQLTnTRhfQmIJhMFg21ihlc9QJ+zjqdr5OA1fH+VjwA2DzMgAzXL+hoZDOlWIVOZq2NYE2j9Ww==}
+     peerDependencies:
+       aws-cdk-lib: 2.164.1
+       constructs: ^10.4.2
+@@ -2503,8 +2503,8 @@ packages:
+     resolution: {integrity: sha512-khrZo4buq4qVmsGzS5yQjKe/WsFvV8fGfOjDQN0q4iy9FjRfPWRgTFrU8u1R2iu/SfWLhY9WnCi4Jhdrcbtg+g==}
+     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+ 
+-  ts-api-utils@1.3.0:
+-    resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
++  ts-api-utils@1.4.0:
++    resolution: {integrity: sha512-032cPxaEKwM+GT3vA5JXNzIaizx388rhsSW79vGRNGXfRRAdEAn2mvk36PvK5HnOchyWZ7afLEXqYCvPCrzuzQ==}
+     engines: {node: '>=16'}
+     peerDependencies:
+       typescript: '>=4.2.0'
+@@ -2784,23 +2784,23 @@ snapshots:
+ 
+   '@aws-cdk/cloud-assembly-schema@38.0.1': {}
+ 
+-  '@babel/code-frame@7.26.0':
++  '@babel/code-frame@7.26.2':
+     dependencies:
+       '@babel/helper-validator-identifier': 7.25.9
+       js-tokens: 4.0.0
+       picocolors: 1.1.1
+ 
+-  '@babel/compat-data@7.26.0': {}
++  '@babel/compat-data@7.26.2': {}
+ 
+   '@babel/core@7.26.0':
+     dependencies:
+       '@ampproject/remapping': 2.3.0
+-      '@babel/code-frame': 7.26.0
+-      '@babel/generator': 7.26.0
++      '@babel/code-frame': 7.26.2
++      '@babel/generator': 7.26.2
+       '@babel/helper-compilation-targets': 7.25.9
+       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
+       '@babel/helpers': 7.26.0
+-      '@babel/parser': 7.26.1
++      '@babel/parser': 7.26.2
+       '@babel/template': 7.25.9
+       '@babel/traverse': 7.25.9
+       '@babel/types': 7.26.0
+@@ -2812,9 +2812,9 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
+-  '@babel/generator@7.26.0':
++  '@babel/generator@7.26.2':
+     dependencies:
+-      '@babel/parser': 7.26.1
++      '@babel/parser': 7.26.2
+       '@babel/types': 7.26.0
+       '@jridgewell/gen-mapping': 0.3.5
+       '@jridgewell/trace-mapping': 0.3.25
+@@ -2822,7 +2822,7 @@ snapshots:
+ 
+   '@babel/helper-compilation-targets@7.25.9':
+     dependencies:
+-      '@babel/compat-data': 7.26.0
++      '@babel/compat-data': 7.26.2
+       '@babel/helper-validator-option': 7.25.9
+       browserslist: 4.24.2
+       lru-cache: 5.1.1
+@@ -2857,7 +2857,7 @@ snapshots:
+       '@babel/template': 7.25.9
+       '@babel/types': 7.26.0
+ 
+-  '@babel/parser@7.26.1':
++  '@babel/parser@7.26.2':
+     dependencies:
+       '@babel/types': 7.26.0
+ 
+@@ -2948,15 +2948,15 @@ snapshots:
+ 
+   '@babel/template@7.25.9':
+     dependencies:
+-      '@babel/code-frame': 7.26.0
+-      '@babel/parser': 7.26.1
++      '@babel/code-frame': 7.26.2
++      '@babel/parser': 7.26.2
+       '@babel/types': 7.26.0
+ 
+   '@babel/traverse@7.25.9':
+     dependencies:
+-      '@babel/code-frame': 7.26.0
+-      '@babel/generator': 7.26.0
+-      '@babel/parser': 7.26.1
++      '@babel/code-frame': 7.26.2
++      '@babel/generator': 7.26.2
++      '@babel/parser': 7.26.2
+       '@babel/template': 7.25.9
+       '@babel/types': 7.26.0
+       debug: 4.3.7
+@@ -3309,7 +3309,7 @@ snapshots:
+ 
+   '@types/babel__core@7.20.5':
+     dependencies:
+-      '@babel/parser': 7.26.1
++      '@babel/parser': 7.26.2
+       '@babel/types': 7.26.0
+       '@types/babel__generator': 7.6.8
+       '@types/babel__template': 7.4.4
+@@ -3321,7 +3321,7 @@ snapshots:
+ 
+   '@types/babel__template@7.4.4':
+     dependencies:
+-      '@babel/parser': 7.26.1
++      '@babel/parser': 7.26.2
+       '@babel/types': 7.26.0
+ 
+   '@types/babel__traverse@7.20.6':
+@@ -3393,7 +3393,7 @@ snapshots:
+       graphemer: 1.4.0
+       ignore: 5.3.2
+       natural-compare: 1.4.0
+-      ts-api-utils: 1.3.0(typescript@5.6.3)
++      ts-api-utils: 1.4.0(typescript@5.6.3)
+     optionalDependencies:
+       typescript: 5.6.3
+     transitivePeerDependencies:
+@@ -3422,7 +3422,7 @@ snapshots:
+       '@typescript-eslint/typescript-estree': 8.12.2(typescript@5.6.3)
+       '@typescript-eslint/utils': 8.12.2(eslint@9.13.0)(typescript@5.6.3)
+       debug: 4.3.7
+-      ts-api-utils: 1.3.0(typescript@5.6.3)
++      ts-api-utils: 1.4.0(typescript@5.6.3)
+     optionalDependencies:
+       typescript: 5.6.3
+     transitivePeerDependencies:
+@@ -3440,7 +3440,7 @@ snapshots:
+       is-glob: 4.0.3
+       minimatch: 9.0.5
+       semver: 7.6.3
+-      ts-api-utils: 1.3.0(typescript@5.6.3)
++      ts-api-utils: 1.4.0(typescript@5.6.3)
+     optionalDependencies:
+       typescript: 5.6.3
+     transitivePeerDependencies:
+@@ -3471,7 +3471,7 @@ snapshots:
+ 
+   '@vue/compiler-core@3.5.12':
+     dependencies:
+-      '@babel/parser': 7.26.1
++      '@babel/parser': 7.26.2
+       '@vue/shared': 3.5.12
+       entities: 4.5.0
+       estree-walker: 2.0.2
+@@ -3484,7 +3484,7 @@ snapshots:
+ 
+   '@vue/compiler-sfc@3.5.12':
+     dependencies:
+-      '@babel/parser': 7.26.1
++      '@babel/parser': 7.26.2
+       '@vue/compiler-core': 3.5.12
+       '@vue/compiler-dom': 3.5.12
+       '@vue/compiler-ssr': 3.5.12
+@@ -4591,7 +4591,7 @@ snapshots:
+   istanbul-lib-instrument@5.2.1:
+     dependencies:
+       '@babel/core': 7.26.0
+-      '@babel/parser': 7.26.1
++      '@babel/parser': 7.26.2
+       '@istanbuljs/schema': 0.1.3
+       istanbul-lib-coverage: 3.2.2
+       semver: 6.3.1
+@@ -4601,7 +4601,7 @@ snapshots:
+   istanbul-lib-instrument@6.0.3:
+     dependencies:
+       '@babel/core': 7.26.0
+-      '@babel/parser': 7.26.1
++      '@babel/parser': 7.26.2
+       '@istanbuljs/schema': 0.1.3
+       istanbul-lib-coverage: 3.2.2
+       semver: 7.6.3
+@@ -4776,7 +4776,7 @@ snapshots:
+ 
+   jest-message-util@29.7.0:
+     dependencies:
+-      '@babel/code-frame': 7.26.0
++      '@babel/code-frame': 7.26.2
+       '@jest/types': 29.6.3
+       '@types/stack-utils': 2.0.3
+       chalk: 4.1.2
+@@ -4873,7 +4873,7 @@ snapshots:
+   jest-snapshot@29.7.0:
+     dependencies:
+       '@babel/core': 7.26.0
+-      '@babel/generator': 7.26.0
++      '@babel/generator': 7.26.2
+       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.0)
+       '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.0)
+       '@babel/types': 7.26.0
+@@ -5458,7 +5458,7 @@ snapshots:
+ 
+   p-try@2.2.0: {}
+ 
+-  p6-cdk-website-plus@0.3.5(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2):
++  p6-cdk-website-plus@1.0.0(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2):
+     dependencies:
+       aws-cdk-lib: 2.164.1(constructs@10.4.2)
+       constructs: 10.4.2
+@@ -5478,7 +5478,7 @@ snapshots:
+ 
+   parse-json@5.2.0:
+     dependencies:
+-      '@babel/code-frame': 7.26.0
++      '@babel/code-frame': 7.26.2
+       error-ex: 1.3.2
+       json-parse-even-better-errors: 2.3.1
+       lines-and-columns: 1.2.4
+@@ -5798,7 +5798,7 @@ snapshots:
+     dependencies:
+       eslint-visitor-keys: 3.4.3
+ 
+-  ts-api-utils@1.3.0(typescript@5.6.3):
++  ts-api-utils@1.4.0(typescript@5.6.3):
+     dependencies:
+       typescript: 5.6.3
+ 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "aws-cdk-lib": "2.164.1",
     "constructs": "^10.4.2",
     "js-yaml": "^4.1.0",
-    "p6-cdk-website-plus": "^0.3.5",
+    "p6-cdk-website-plus": "^1.0.0",
     "source-map-support": "^0.5.21"
   },
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       p6-cdk-website-plus:
-        specifier: ^0.3.5
-        version: 0.3.5(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2)
+        specifier: ^1.0.0
+        version: 1.0.0(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2)
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -137,20 +137,20 @@ packages:
       - jsonschema
       - semver
 
-  '@babel/code-frame@7.26.0':
-    resolution: {integrity: sha512-INCKxTtbXtcNbUZ3YXutwMpEleqttcswhAdee7dhuoVrD2cnuc3PqtERBtxkX5nziX9vnBL8WXmSGwv8CuPV6g==}
+  '@babel/code-frame@7.26.2':
+    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.26.0':
-    resolution: {integrity: sha512-qETICbZSLe7uXv9VE8T/RWOdIE5qqyTucOt4zLYMafj2MRO271VGgLd4RACJMeBO37UPWhXiKMBk7YlJ0fOzQA==}
+  '@babel/compat-data@7.26.2':
+    resolution: {integrity: sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.26.0':
     resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.26.0':
-    resolution: {integrity: sha512-/AIkAmInnWwgEAJGQr9vY0c66Mj6kjkE2ZPB1PurTRaRAh3U+J45sAQMjQDJdh4WbR3l0x5xkimXBKyBXXAu2w==}
+  '@babel/generator@7.26.2':
+    resolution: {integrity: sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.25.9':
@@ -187,8 +187,8 @@ packages:
     resolution: {integrity: sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.26.1':
-    resolution: {integrity: sha512-reoQYNiAJreZNsJzyrDNzFQ+IQ5JFiIzAHJg9bn94S3l+4++J7RsIhNMoB+lgP/9tpmiAQqspv+xfdxTSzREOw==}
+  '@babel/parser@7.26.2':
+    resolution: {integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2150,8 +2150,8 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  p6-cdk-website-plus@0.3.5:
-    resolution: {integrity: sha512-NN3g+5+Hrr8yMRiqRvVoblT1dRXEa0vpIXwiilT+as0wP4rJMZ0f+aU8M8+YePxjO9phaPPgEsEo38QBGV8Efw==}
+  p6-cdk-website-plus@1.0.0:
+    resolution: {integrity: sha512-UUHIQPUzEMrThQLTnTRhfQmIJhMFg21ihlc9QJ+zjqdr5OA1fH+VjwA2DzMgAzXL+hoZDOlWIVOZq2NYE2j9Ww==}
     peerDependencies:
       aws-cdk-lib: 2.164.1
       constructs: ^10.4.2
@@ -2503,8 +2503,8 @@ packages:
     resolution: {integrity: sha512-khrZo4buq4qVmsGzS5yQjKe/WsFvV8fGfOjDQN0q4iy9FjRfPWRgTFrU8u1R2iu/SfWLhY9WnCi4Jhdrcbtg+g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  ts-api-utils@1.3.0:
-    resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
+  ts-api-utils@1.4.0:
+    resolution: {integrity: sha512-032cPxaEKwM+GT3vA5JXNzIaizx388rhsSW79vGRNGXfRRAdEAn2mvk36PvK5HnOchyWZ7afLEXqYCvPCrzuzQ==}
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
@@ -2784,23 +2784,23 @@ snapshots:
 
   '@aws-cdk/cloud-assembly-schema@38.0.1': {}
 
-  '@babel/code-frame@7.26.0':
+  '@babel/code-frame@7.26.2':
     dependencies:
       '@babel/helper-validator-identifier': 7.25.9
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.26.0': {}
+  '@babel/compat-data@7.26.2': {}
 
   '@babel/core@7.26.0':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.26.0
-      '@babel/generator': 7.26.0
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.2
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
       '@babel/helpers': 7.26.0
-      '@babel/parser': 7.26.1
+      '@babel/parser': 7.26.2
       '@babel/template': 7.25.9
       '@babel/traverse': 7.25.9
       '@babel/types': 7.26.0
@@ -2812,9 +2812,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.26.0':
+  '@babel/generator@7.26.2':
     dependencies:
-      '@babel/parser': 7.26.1
+      '@babel/parser': 7.26.2
       '@babel/types': 7.26.0
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
@@ -2822,7 +2822,7 @@ snapshots:
 
   '@babel/helper-compilation-targets@7.25.9':
     dependencies:
-      '@babel/compat-data': 7.26.0
+      '@babel/compat-data': 7.26.2
       '@babel/helper-validator-option': 7.25.9
       browserslist: 4.24.2
       lru-cache: 5.1.1
@@ -2857,7 +2857,7 @@ snapshots:
       '@babel/template': 7.25.9
       '@babel/types': 7.26.0
 
-  '@babel/parser@7.26.1':
+  '@babel/parser@7.26.2':
     dependencies:
       '@babel/types': 7.26.0
 
@@ -2948,15 +2948,15 @@ snapshots:
 
   '@babel/template@7.25.9':
     dependencies:
-      '@babel/code-frame': 7.26.0
-      '@babel/parser': 7.26.1
+      '@babel/code-frame': 7.26.2
+      '@babel/parser': 7.26.2
       '@babel/types': 7.26.0
 
   '@babel/traverse@7.25.9':
     dependencies:
-      '@babel/code-frame': 7.26.0
-      '@babel/generator': 7.26.0
-      '@babel/parser': 7.26.1
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.2
+      '@babel/parser': 7.26.2
       '@babel/template': 7.25.9
       '@babel/types': 7.26.0
       debug: 4.3.7
@@ -3309,7 +3309,7 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.26.1
+      '@babel/parser': 7.26.2
       '@babel/types': 7.26.0
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
@@ -3321,7 +3321,7 @@ snapshots:
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.26.1
+      '@babel/parser': 7.26.2
       '@babel/types': 7.26.0
 
   '@types/babel__traverse@7.20.6':
@@ -3393,7 +3393,7 @@ snapshots:
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.6.3)
+      ts-api-utils: 1.4.0(typescript@5.6.3)
     optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -3422,7 +3422,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.12.2(typescript@5.6.3)
       '@typescript-eslint/utils': 8.12.2(eslint@9.13.0)(typescript@5.6.3)
       debug: 4.3.7
-      ts-api-utils: 1.3.0(typescript@5.6.3)
+      ts-api-utils: 1.4.0(typescript@5.6.3)
     optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -3440,7 +3440,7 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.6.3)
+      ts-api-utils: 1.4.0(typescript@5.6.3)
     optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -3471,7 +3471,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.12':
     dependencies:
-      '@babel/parser': 7.26.1
+      '@babel/parser': 7.26.2
       '@vue/shared': 3.5.12
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -3484,7 +3484,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.12':
     dependencies:
-      '@babel/parser': 7.26.1
+      '@babel/parser': 7.26.2
       '@vue/compiler-core': 3.5.12
       '@vue/compiler-dom': 3.5.12
       '@vue/compiler-ssr': 3.5.12
@@ -4591,7 +4591,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/parser': 7.26.1
+      '@babel/parser': 7.26.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -4601,7 +4601,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/parser': 7.26.1
+      '@babel/parser': 7.26.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.6.3
@@ -4776,7 +4776,7 @@ snapshots:
 
   jest-message-util@29.7.0:
     dependencies:
-      '@babel/code-frame': 7.26.0
+      '@babel/code-frame': 7.26.2
       '@jest/types': 29.6.3
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -4873,7 +4873,7 @@ snapshots:
   jest-snapshot@29.7.0:
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/generator': 7.26.0
+      '@babel/generator': 7.26.2
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.0)
       '@babel/types': 7.26.0
@@ -5458,7 +5458,7 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  p6-cdk-website-plus@0.3.5(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2):
+  p6-cdk-website-plus@1.0.0(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
       aws-cdk-lib: 2.164.1(constructs@10.4.2)
       constructs: 10.4.2
@@ -5478,7 +5478,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.26.0
+      '@babel/code-frame': 7.26.2
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -5798,7 +5798,7 @@ snapshots:
     dependencies:
       eslint-visitor-keys: 3.4.3
 
-  ts-api-utils@1.3.0(typescript@5.6.3):
+  ts-api-utils@1.4.0(typescript@5.6.3):
     dependencies:
       typescript: 5.6.3
 


### PR DESCRIPTION
Upgrades project dependencies. The following changes were made:
```diff
diff --git a/package.json b/package.json
index 08b60ea..684a751 100644
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "aws-cdk-lib": "2.164.1",
     "constructs": "^10.4.2",
     "js-yaml": "^4.1.0",
-    "p6-cdk-website-plus": "^0.3.5",
+    "p6-cdk-website-plus": "^1.0.0",
     "source-map-support": "^0.5.21"
   },
   "keywords": [
diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
index 3d144f8..010348b 100644
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       p6-cdk-website-plus:
-        specifier: ^0.3.5
-        version: 0.3.5(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2)
+        specifier: ^1.0.0
+        version: 1.0.0(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2)
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -137,20 +137,20 @@ packages:
       - jsonschema
       - semver
 
-  '@babel/code-frame@7.26.0':
-    resolution: {integrity: sha512-INCKxTtbXtcNbUZ3YXutwMpEleqttcswhAdee7dhuoVrD2cnuc3PqtERBtxkX5nziX9vnBL8WXmSGwv8CuPV6g==}
+  '@babel/code-frame@7.26.2':
+    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.26.0':
-    resolution: {integrity: sha512-qETICbZSLe7uXv9VE8T/RWOdIE5qqyTucOt4zLYMafj2MRO271VGgLd4RACJMeBO37UPWhXiKMBk7YlJ0fOzQA==}
+  '@babel/compat-data@7.26.2':
+    resolution: {integrity: sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.26.0':
     resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.26.0':
-    resolution: {integrity: sha512-/AIkAmInnWwgEAJGQr9vY0c66Mj6kjkE2ZPB1PurTRaRAh3U+J45sAQMjQDJdh4WbR3l0x5xkimXBKyBXXAu2w==}
+  '@babel/generator@7.26.2':
+    resolution: {integrity: sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.25.9':
@@ -187,8 +187,8 @@ packages:
     resolution: {integrity: sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.26.1':
-    resolution: {integrity: sha512-reoQYNiAJreZNsJzyrDNzFQ+IQ5JFiIzAHJg9bn94S3l+4++J7RsIhNMoB+lgP/9tpmiAQqspv+xfdxTSzREOw==}
+  '@babel/parser@7.26.2':
+    resolution: {integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2150,8 +2150,8 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  p6-cdk-website-plus@0.3.5:
-    resolution: {integrity: sha512-NN3g+5+Hrr8yMRiqRvVoblT1dRXEa0vpIXwiilT+as0wP4rJMZ0f+aU8M8+YePxjO9phaPPgEsEo38QBGV8Efw==}
+  p6-cdk-website-plus@1.0.0:
+    resolution: {integrity: sha512-UUHIQPUzEMrThQLTnTRhfQmIJhMFg21ihlc9QJ+zjqdr5OA1fH+VjwA2DzMgAzXL+hoZDOlWIVOZq2NYE2j9Ww==}
     peerDependencies:
       aws-cdk-lib: 2.164.1
       constructs: ^10.4.2
@@ -2503,8 +2503,8 @@ packages:
     resolution: {integrity: sha512-khrZo4buq4qVmsGzS5yQjKe/WsFvV8fGfOjDQN0q4iy9FjRfPWRgTFrU8u1R2iu/SfWLhY9WnCi4Jhdrcbtg+g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  ts-api-utils@1.3.0:
-    resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
+  ts-api-utils@1.4.0:
+    resolution: {integrity: sha512-032cPxaEKwM+GT3vA5JXNzIaizx388rhsSW79vGRNGXfRRAdEAn2mvk36PvK5HnOchyWZ7afLEXqYCvPCrzuzQ==}
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
@@ -2784,23 +2784,23 @@ snapshots:
 
   '@aws-cdk/cloud-assembly-schema@38.0.1': {}
 
-  '@babel/code-frame@7.26.0':
+  '@babel/code-frame@7.26.2':
     dependencies:
       '@babel/helper-validator-identifier': 7.25.9
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.26.0': {}
+  '@babel/compat-data@7.26.2': {}
 
   '@babel/core@7.26.0':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.26.0
-      '@babel/generator': 7.26.0
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.2
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
       '@babel/helpers': 7.26.0
-      '@babel/parser': 7.26.1
+      '@babel/parser': 7.26.2
       '@babel/template': 7.25.9
       '@babel/traverse': 7.25.9
       '@babel/types': 7.26.0
@@ -2812,9 +2812,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.26.0':
+  '@babel/generator@7.26.2':
     dependencies:
-      '@babel/parser': 7.26.1
+      '@babel/parser': 7.26.2
       '@babel/types': 7.26.0
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
@@ -2822,7 +2822,7 @@ snapshots:
 
   '@babel/helper-compilation-targets@7.25.9':
     dependencies:
-      '@babel/compat-data': 7.26.0
+      '@babel/compat-data': 7.26.2
       '@babel/helper-validator-option': 7.25.9
       browserslist: 4.24.2
       lru-cache: 5.1.1
@@ -2857,7 +2857,7 @@ snapshots:
       '@babel/template': 7.25.9
       '@babel/types': 7.26.0
 
-  '@babel/parser@7.26.1':
+  '@babel/parser@7.26.2':
     dependencies:
       '@babel/types': 7.26.0
 
@@ -2948,15 +2948,15 @@ snapshots:
 
   '@babel/template@7.25.9':
     dependencies:
-      '@babel/code-frame': 7.26.0
-      '@babel/parser': 7.26.1
+      '@babel/code-frame': 7.26.2
+      '@babel/parser': 7.26.2
       '@babel/types': 7.26.0
 
   '@babel/traverse@7.25.9':
     dependencies:
-      '@babel/code-frame': 7.26.0
-      '@babel/generator': 7.26.0
-      '@babel/parser': 7.26.1
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.2
+      '@babel/parser': 7.26.2
       '@babel/template': 7.25.9
       '@babel/types': 7.26.0
       debug: 4.3.7
@@ -3309,7 +3309,7 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.26.1
+      '@babel/parser': 7.26.2
       '@babel/types': 7.26.0
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
@@ -3321,7 +3321,7 @@ snapshots:
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.26.1
+      '@babel/parser': 7.26.2
       '@babel/types': 7.26.0
 
   '@types/babel__traverse@7.20.6':
@@ -3393,7 +3393,7 @@ snapshots:
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.6.3)
+      ts-api-utils: 1.4.0(typescript@5.6.3)
     optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -3422,7 +3422,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.12.2(typescript@5.6.3)
       '@typescript-eslint/utils': 8.12.2(eslint@9.13.0)(typescript@5.6.3)
       debug: 4.3.7
-      ts-api-utils: 1.3.0(typescript@5.6.3)
+      ts-api-utils: 1.4.0(typescript@5.6.3)
     optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -3440,7 +3440,7 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.6.3)
+      ts-api-utils: 1.4.0(typescript@5.6.3)
     optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -3471,7 +3471,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.12':
     dependencies:
-      '@babel/parser': 7.26.1
+      '@babel/parser': 7.26.2
       '@vue/shared': 3.5.12
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -3484,7 +3484,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.12':
     dependencies:
-      '@babel/parser': 7.26.1
+      '@babel/parser': 7.26.2
       '@vue/compiler-core': 3.5.12
       '@vue/compiler-dom': 3.5.12
       '@vue/compiler-ssr': 3.5.12
@@ -4591,7 +4591,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/parser': 7.26.1
+      '@babel/parser': 7.26.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -4601,7 +4601,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/parser': 7.26.1
+      '@babel/parser': 7.26.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.6.3
@@ -4776,7 +4776,7 @@ snapshots:
 
   jest-message-util@29.7.0:
     dependencies:
-      '@babel/code-frame': 7.26.0
+      '@babel/code-frame': 7.26.2
       '@jest/types': 29.6.3
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -4873,7 +4873,7 @@ snapshots:
   jest-snapshot@29.7.0:
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/generator': 7.26.0
+      '@babel/generator': 7.26.2
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.0)
       '@babel/types': 7.26.0
@@ -5458,7 +5458,7 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  p6-cdk-website-plus@0.3.5(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2):
+  p6-cdk-website-plus@1.0.0(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
       aws-cdk-lib: 2.164.1(constructs@10.4.2)
       constructs: 10.4.2
@@ -5478,7 +5478,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.26.0
+      '@babel/code-frame': 7.26.2
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -5798,7 +5798,7 @@ snapshots:
     dependencies:
       eslint-visitor-keys: 3.4.3
 
-  ts-api-utils@1.3.0(typescript@5.6.3):
+  ts-api-utils@1.4.0(typescript@5.6.3):
     dependencies:
       typescript: 5.6.3
 
```